### PR TITLE
updated title from "NATS" to "NATS for Ruby"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NATS
+# NATS for Ruby
 
 A lightweight publish-subscribe and distributed queueing messaging system.
 


### PR DESCRIPTION
@derekcollison Added "Ruby" to the Readme title to improve nats.io docs navigation. (Currently, people click the "Ruby" menu option, but still just see "NATS".) Thanks! 