### PR TITLE
Never remove servers when configured as such

### DIFF
--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -9,7 +9,7 @@ require "#{ep}/ext/json"
 
 module NATS
 
-  VERSION = "0.5.0".freeze
+  VERSION = "0.5.1".freeze
 
   DEFAULT_PORT = 4222
   DEFAULT_URI = "nats://localhost:#{DEFAULT_PORT}".freeze
@@ -791,7 +791,7 @@ module NATS
     # Dump the one we were trying if it wasn't connected
     current = server_pool.shift
     # FIXME(dlc) - Should we remove from the list on error?
-    server_pool << current if (current && can_reuse_server?(current) && !current[:error_received])
+    server_pool << current if (current && (options[:max_reconnect_attempts] < 0 || can_reuse_server?(current) && !current[:error_received]))
     # If we are out of options, go ahead and disconnect.
     process_disconnect and return if server_pool.empty?
     # bind new one

--- a/lib/nats/server/const.rb
+++ b/lib/nats/server/const.rb
@@ -1,7 +1,7 @@
 
 module NATSD #:nodoc:
 
-  VERSION  = '0.5.0'
+  VERSION  = '0.5.1'
   APP_NAME = 'nats-server'
 
   DEFAULT_PORT = 4222

--- a/spec/client_cluster_reconnect_spec.rb
+++ b/spec/client_cluster_reconnect_spec.rb
@@ -129,4 +129,22 @@ describe 'client cluster reconnect' do
     end
   end
 
+  context 'when max_reconnect_attempts == -1 (do not remove servers)' do
+    it 'should never remove servers that fail' do
+      options = {
+        :dont_randomize_servers => true,
+        :servers => [@s1.uri, @s2.uri],
+        :reconnect => true,
+        :max_reconnect_attempts => -1,
+        :reconnect_time_wait => 1
+      }
+
+      @s1.kill_server
+      NATS.start(options) do |c|
+        timeout_nats_on_failure(15)
+        c.connected_server.should == @s2.uri
+        expect(c.server_pool.size).to eq(2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
follow the go-nats client behavior and respect when servers should not be
removed on failed connectes

See issue #87 