### PR TITLE
Silence warning when setting epoll or kqueue by detecting it first

### DIFF
--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -151,7 +151,13 @@ module NATS
         raise(Error, "EM needs to be running when NATS.start is called without a run block")
       end
       # Setup optimized select versions
-      EM.epoll; EM.kqueue
+      if EM.epoll?
+        EM.epoll
+      elsif EM.kqueue?
+        EM.kqueue
+      else
+        Kernel.warn('Neither epoll nor kqueue are supported')
+      end
       EM.run { @client = connect(*args, &blk) }
     end
 


### PR DESCRIPTION
It used to be the case that EventMachine would not throw warnings and calling `EM.epoll` or `EM.kqueue` would be a no-op in case there was no support for it on the platform.
https://github.com/eventmachine/eventmachine/blob/master/docs/old/EPOLL#L42

Due to changes in EventMachine 1.0.8 (https://github.com/eventmachine/eventmachine/commit/9af94064e1f05b373145ba0c3cac41daa9daf369),
now warnings like these are thrown when using the client:

```
warning: epoll is not supported on this platform
warning: kqueue is not supported on this platform
```

This patch silences these warnings once again to get the old behavior. Fixes #89 
