### PR TITLE
Initialize variables @buf and @ssl.

### DIFF
--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -320,9 +320,9 @@ module NATS
   def initialize(options)
     @options = options
     process_uri_options
-    @buf = nil
     @ssl = false
     @ssl = options[:ssl] if options[:ssl]
+    @buf = nil
     @ssid, @subs = 1, {}
     @err_cb = NATS.err_cb
     @reconnect_timer, @needed = nil, nil

--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -320,6 +320,8 @@ module NATS
   def initialize(options)
     @options = options
     process_uri_options
+    @buf = nil
+    @ssl = false
     @ssl = options[:ssl] if options[:ssl]
     @ssid, @subs = 1, {}
     @err_cb = NATS.err_cb


### PR DESCRIPTION
@buf and @ssl were not initialized in some cases such as when options did not have an options[:ssl] value.