### PR TITLE
Apply subs whenever connect is completed

### DIFF
--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -636,8 +636,9 @@ module NATS
 
     if reconnecting?
       cancel_reconnect_timer
-      @subs.each_pair { |k, v| send_command("SUB #{v[:subject]} #{v[:queue]} #{k}#{CR_LF}") }
     end
+
+    @subs.each_pair { |k, v| send_command("SUB #{v[:subject]} #{v[:queue]} #{k}#{CR_LF}") }
 
     unless user_err_cb? or reconnecting?
       @err_cb = proc { |e| raise e }


### PR DESCRIPTION
If there is an error connecting the first time, reconnecting is false and outstanding subs are never added.
Always add subscriptions whether you are successfully connecting for the first time or not.