### PR TITLE
Remove extra pending SUBs command which can appear when connecting

### DIFF
--- a/spec/client/sub_timeouts_spec.rb
+++ b/spec/client/sub_timeouts_spec.rb
@@ -23,7 +23,7 @@ describe 'Client - subscriptions with timeouts' do
     received.should == 0
   end
 
-  it "a subsciption should call the timeout callback if no messages are received" do
+  it "a subscription should call the timeout callback if no messages are received" do
     received = 0
     timeout_recvd = false
     NATS.start do
@@ -35,7 +35,7 @@ describe 'Client - subscriptions with timeouts' do
     received.should == 0
   end
 
-  it "a subsciption should call the timeout callback if no messages are received, connection version" do
+  it "a subscription should call the timeout callback if no messages are received, connection version" do
     received = 0
     timeout_recvd = false
     NATS.start do |c|
@@ -47,7 +47,7 @@ describe 'Client - subscriptions with timeouts' do
     received.should == 0
   end
 
-  it "a subsciption should not call the timeout callback if a message is received" do
+  it "a subscription should not call the timeout callback if a message is received" do
     received = 0
     timeout_recvd = false
     NATS.start do
@@ -61,7 +61,7 @@ describe 'Client - subscriptions with timeouts' do
     received.should == 2
   end
 
-  it "a subsciption should not call the timeout callback if a correct # messages are received" do
+  it "a subscription should not call the timeout callback if a correct # messages are received" do
     received = 0
     timeout_recvd = false
     NATS.start do
@@ -75,7 +75,7 @@ describe 'Client - subscriptions with timeouts' do
     received.should == 2
   end
 
-  it "a subsciption should call the timeout callback if a correct # messages are not received" do
+  it "a subscription should call the timeout callback if a correct # messages are not received" do
     received = 0
     timeout_recvd = false
     NATS.start do
@@ -88,7 +88,7 @@ describe 'Client - subscriptions with timeouts' do
     received.should == 1
   end
 
-  it "a subsciption should call the timeout callback and message callback if requested" do
+  it "a subscription should call the timeout callback and message callback if requested" do
     received = 0
     timeout_recvd = false
     NATS.start do


### PR DESCRIPTION
Follow up from [previous commit](https://github.com/nats-io/ruby-nats/commit/3f3efc6bc41cc483f2d90cb9d401ba4aa3e727d3), where unnecessary `SUB` commands can be sent to the server because of being buffered before connecting. In order to avoid sending extra `SUB` commands, we detect and remove them once reaching `connection_completed`. 
/cc @derekcollison 