### PR TITLE
Add version.rb file to list in gemspec and require in client

### DIFF
--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -6,6 +6,7 @@ ep = File.expand_path(File.dirname(__FILE__))
 require "#{ep}/ext/em"
 require "#{ep}/ext/bytesize"
 require "#{ep}/ext/json"
+require "#{ep}/version"
 
 module NATS
 

--- a/nats.gemspec
+++ b/nats.gemspec
@@ -39,6 +39,7 @@ spec = Gem::Specification.new do |s|
     bin/nats-top
     bin/nats-request
     lib/nats/client.rb
+    lib/nats/version.rb
     lib/nats/ext/bytesize.rb
     lib/nats/ext/em.rb
     lib/nats/ext/json.rb


### PR DESCRIPTION
Added a `nats/version.rb` file to load it in the gemspec, though also has to be added into the files in the gemspec and required by the client too in order to send to send the version to the server on connect...