### PR TITLE
Count outstanding pings correctly

### DIFF
--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -759,12 +759,12 @@ module NATS
 
   def send_ping #:nodoc:
     return if @closing
+    @pings_outstanding += 1
     if @pings_outstanding > @options[:max_outstanding_pings]
       close_connection
       #close
       return
     end
-    @pings_outstanding += 1
     queue_server_rt { process_pong }
     flush_pending
   end


### PR DESCRIPTION
Wait until N pings are outstanding before closing the connection. The previous code was closing on N + 1.
This aligns with how the counting is also done in the Go client.