### PR TITLE
Avoid warning about EventMachine.epoll / kqueue on JRuby

### DIFF
--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -173,8 +173,10 @@ module NATS
         EM.epoll
       elsif EM.kqueue?
         EM.kqueue
+      elsif EM.library_type == :java
+        # No warning needed, we're using Java NIO
       else
-        Kernel.warn('Neither epoll nor kqueue are supported')
+        Kernel.warn('Neither epoll nor kqueue are supported, performance may be impacted')
       end
       EM.run { @client = connect(*args, &blk) }
     end


### PR DESCRIPTION
A user worried that Nats wasn't working under JRuby because of this warning. 
https://github.com/nats-io/ruby-nats/issues/72#issuecomment-233789670
https://github.com/eventmachine/eventmachine/issues/724
