### PR TITLE
Add more rubies and jruby to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
   include:
     - rvm: jruby
       env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
-    - rvm: jruby-head
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
   allow_failures:
     - rvm: jruby
       env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 rvm:
   - 2.2
   - 2.3.0
+  - 2.4.0-preview1
+  - ruby-head  
 
 cache:
   directories:
@@ -16,3 +18,16 @@ before_script:
 
 sudo: required
 dist: trusty
+bundler_args: --without server
+
+matrix:
+  include:
+    - rvm: jruby
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+    - rvm: jruby-head
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+  allow_failures:
+    - rvm: jruby
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+    - rvm: ruby-head
+    - rvm: 2.4.0-preview1

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,13 @@ source "http://rubygems.org"
 
 gemspec
 
-gem 'eventmachine', '>= 1.2.0'
-gem 'daemons', '>= 1.2.2'
-gem 'json_pure', '>= 1.8.1', :require => 'json'
-gem 'thin', '>= 1.6.0'
-
 group :test do
   gem 'rake'
   gem 'rspec', '< 3.0.0'
+end
+
+group :server do
+  gem 'daemons', '>= 1.2.2'
+  gem 'json_pure', '>= 1.8.1', :require => 'json'
+  gem 'thin', '>= 1.6.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :test do
   gem 'rake'
-  gem 'rspec', '< 3.0.0'
+  gem 'rspec', '>= 3.5.0'
 end
 
 group :server do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,33 +10,37 @@ GEM
     daemons (1.2.3)
     diff-lcs (1.2.5)
     eventmachine (1.2.0.1)
-    json_pure (1.8.3)
-    rack (1.6.4)
-    rake (11.1.2)
-    rspec (2.99.0)
-      rspec-core (~> 2.99.0)
-      rspec-expectations (~> 2.99.0)
-      rspec-mocks (~> 2.99.0)
-    rspec-core (2.99.2)
-    rspec-expectations (2.99.2)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.99.4)
-    thin (1.6.4)
+    json_pure (2.0.2)
+    rack (2.0.1)
+    rake (11.2.2)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.1)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    thin (1.7.0)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
-      rack (~> 1.0)
+      rack (>= 1, < 3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   daemons (>= 1.2.2)
-  eventmachine (>= 1.2.0)
   json_pure (>= 1.8.1)
   nats!
   rake
-  rspec (< 3.0.0)
+  rspec (>= 3.5.0)
   thin (>= 1.6.0)
 
 BUNDLED WITH
-   1.12.3
+   1.12.5

--- a/Rakefile
+++ b/Rakefile
@@ -2,12 +2,13 @@
 require 'rspec/core'
 require 'rspec/core/rake_task'
 
+task :default => 'spec:client'
+
 desc 'Run specs from client and server'
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
   spec.rspec_opts = ["--format", "documentation", "--colour"]
 end
-task :default => 'spec:client'
 
 desc 'Run spec from client using gnatsd as the server'
 RSpec::Core::RakeTask.new('spec:client') do |spec|

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
   spec.rspec_opts = ["--format", "documentation", "--colour"]
 end
-task :default => :spec
+task :default => 'spec:client'
 
 desc 'Run spec from client using gnatsd as the server'
 RSpec::Core::RakeTask.new('spec:client') do |spec|


### PR DESCRIPTION
Mark those considered to be experimental under allowed_failures in Travis. 
Also moves server deps under bundle group in Gemfile and only runs client tests by default in CI env.