### PR TITLE
Add more jruby versions to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,32 @@ matrix:
   include:
     - rvm: jruby
       env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      script: "bundle exec rake spec:client:jruby"
+      jdk: openjdk7
+    - rvm: jruby
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      script: "bundle exec rake spec:client:jruby"
+      jdk: oraclejdk7
+    - rvm: jruby
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      script: "bundle exec rake spec:client:jruby"
+      jdk: openjdk8
+    - rvm: jruby
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      script: "bundle exec rake spec:client:jruby"
+      jdk: oraclejdk8
   allow_failures:
     - rvm: jruby
       env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      jdk: openjdk7
+    - rvm: jruby
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      jdk: oraclejdk7
+    - rvm: jruby
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      jdk: openjdk8
+    - rvm: jruby
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      jdk: oraclejdk8
     - rvm: ruby-head
     - rvm: 2.4.0-preview1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 rvm:
   - 2.2
   - 2.3.0
@@ -23,33 +21,33 @@ bundler_args: --without server
 matrix:
   include:
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       script: "bundle exec rake spec:client:jruby"
       jdk: openjdk7
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       script: "bundle exec rake spec:client:jruby"
       jdk: oraclejdk7
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       script: "bundle exec rake spec:client:jruby"
       jdk: openjdk8
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       script: "bundle exec rake spec:client:jruby"
       jdk: oraclejdk8
   allow_failures:
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       jdk: openjdk7
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       jdk: oraclejdk7
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       jdk: openjdk8
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       jdk: oraclejdk8
     - rvm: ruby-head
     - rvm: 2.4.0-preview1

--- a/Rakefile
+++ b/Rakefile
@@ -7,19 +7,19 @@ task :default => 'spec:client'
 desc 'Run specs from client and server'
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
-  spec.rspec_opts = ["--format", "documentation", "--colour"]
+  spec.rspec_opts = ["--format", "documentation", "--colour", "--profile"]
 end
 
 desc 'Run spec from client using gnatsd as the server'
 RSpec::Core::RakeTask.new('spec:client') do |spec|
   spec.pattern = FileList['spec/client/*_spec.rb']
-  spec.rspec_opts = ["--format", "documentation", "--colour"]
+  spec.rspec_opts = ["--format", "documentation", "--colour", "--profile"]
 end
 
 desc 'Run spec from client on jruby using gnatsd as the server'
 RSpec::Core::RakeTask.new('spec:client:jruby') do |spec|
   spec.pattern = FileList['spec/client/*_spec.rb']
-  spec.rspec_opts = ["--format", "documentation", "--colour", "--tag", "~jruby_excluded"]
+  spec.rspec_opts = ["--format", "documentation", "--colour", "--tag", "~jruby_excluded", "--profile"]
 end
 
 desc 'Run spec from server'

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,12 @@ RSpec::Core::RakeTask.new('spec:client') do |spec|
   spec.rspec_opts = ["--format", "documentation", "--colour"]
 end
 
+desc 'Run spec from client on jruby using gnatsd as the server'
+RSpec::Core::RakeTask.new('spec:client:jruby') do |spec|
+  spec.pattern = FileList['spec/client/*_spec.rb']
+  spec.rspec_opts = ["--format", "documentation", "--colour", "--tag", "~jruby_excluded"]
+end
+
 desc 'Run spec from server'
 RSpec::Core::RakeTask.new('spec:server') do |spec|
   spec.pattern = FileList['spec/server/*_spec.rb']

--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -243,7 +243,7 @@ module NATS
     end
 
     # Set the default on_closed callback.
-    # @param [Block] &callback called when will reach a state when will no longer be connected. 
+    # @param [Block] &callback called when will reach a state when will no longer be connected.
     def on_close(&callback)
       @close_cb = callback
       @client.on_close(&callback) unless @client.nil?
@@ -707,7 +707,7 @@ module NATS
     # Mark that we established already TCP connection to the server. In case of TLS,
     # prepare commands which will be dispatched to server and delay flushing until
     # we have processed the INFO line sent by the server and done the handshake.
-    @connected = true 
+    @connected = true
     process_connect
   end
 
@@ -716,7 +716,7 @@ module NATS
     process_connect
   end
 
-  def process_connect #:nodoc:   
+  def process_connect #:nodoc:
     # Reset reconnect attempts since TCP connection has been successful at this point.
     current = server_pool.first
     current[:was_connected] = true

--- a/spec/client/auth_spec.rb
+++ b/spec/client/auth_spec.rb
@@ -62,8 +62,8 @@ describe 'Client - authorization' do
 
       NATS.connect(:uri => TEST_AUTH_SERVER_NO_CRED)
     end
-    auth_error_callbacks.should == 1
-    connect_error_callbacks.should == 1
+    expect(auth_error_callbacks).to eql(1)
+    expect(connect_error_callbacks).to eql(1)
   end
 
   it 'should remove server from the pool on unauthorized access' do
@@ -78,10 +78,10 @@ describe 'Client - authorization' do
         EM.stop
       end
     end
-    error_cb.should == 1
-    connect_cb.should be_truthy
-    NATS.client.should_not == nil
-    NATS.client.server_pool.size.should == 1
+    expect(error_cb).to eql(1)
+    expect(connect_cb).to eql(true)
+    expect(NATS.client).to_not be(nil)
+    expect(NATS.client.server_pool.size).to eql(1)
     NATS.stop # clears err_cb
   end
 

--- a/spec/client/autounsub_spec.rb
+++ b/spec/client/autounsub_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Client - max responses and auto-unsubscribe', :jruby_excluded  do
+describe 'Client - max responses and auto-unsubscribe' do
 
   before(:each) do
     @s = NatsServerControl.new("nats://127.0.0.1:4222")

--- a/spec/client/binary_msg_spec.rb
+++ b/spec/client/binary_msg_spec.rb
@@ -15,11 +15,11 @@ describe 'Client - test binary message payloads to avoid connection drop' do
     got_error = false
     NATS.on_error { got_error = true; NATS.stop }
     NATS.start(:reconnect => false) do
-      NATS.connected?.should == true
+      expect(NATS.connected?).to eql(true)
       NATS.publish('dont_disconnect_me', "\006")
       NATS.flush { NATS.stop }
     end
-    got_error.should == false
+    expect(got_error).to eql(false)
   end
 
 end

--- a/spec/client/client_cluster_reconnect_spec.rb
+++ b/spec/client/client_cluster_reconnect_spec.rb
@@ -145,9 +145,9 @@ describe 'Client - cluster reconnect' do
   it 'should connect to another server if possible before reconnect' do
     NATS.start(:dont_randomize_servers => true, :servers => [@s1.uri, @s2.uri, @s3.uri]) do |c|
       timeout_nats_on_failure(15)
-      c.connected_server.should == @s1.uri
+      expect(c.connected_server).to eql(@s1.uri)
       c.on_reconnect do
-        c.connected_server.should == @s2.uri
+        expect(c.connected_server).to eql(@s2.uri)
         NATS.stop
       end
       @s1.kill_server
@@ -157,12 +157,12 @@ describe 'Client - cluster reconnect' do
   it 'should connect to a previous server if multiple servers exit' do
     NATS.start(:dont_randomize_servers => true, :servers => [@s1.uri, @s2.uri, @s3.uri]) do |c|
       timeout_nats_on_failure(15)
-      c.connected_server.should == @s1.uri
+      expect(c.connected_server).to eql(@s1.uri)
       kill_time = Time.now
 
       expected_uri = nil
       c.on_reconnect do
-        c.connected_server.should == expected_uri
+        expect(c.connected_server).to eql(expected_uri)
         if expected_uri == @s2.uri
           # Expect to connect back to S1
           expected_uri = @s1.uri
@@ -191,10 +191,10 @@ describe 'Client - cluster reconnect' do
     }
     NATS.start(options) do |c|
       timeout_nats_on_failure(15)
-      c.connected_server.should == @s1.uri
+      expect(c.connected_server).to eql(@s1.uri)
       c.on_reconnect do
-        c.connected?.should be_truthy
-        c.connected_server.should == @s1.uri
+        expect(c.connected?).to eql(true)
+        expect(c.connected_server).to eql(@s1.uri)
         NATS.stop
       end
       @s1.kill_server
@@ -215,7 +215,7 @@ describe 'Client - cluster reconnect' do
       @s1.kill_server
       NATS.start(options) do |c|
         timeout_nats_on_failure(15)
-        c.connected_server.should == @s2.uri
+        expect(c.connected_server).to eql(@s2.uri)
         expect(c.server_pool.size).to eq(2)
       end
     end

--- a/spec/client/client_spec.rb
+++ b/spec/client/client_spec.rb
@@ -430,7 +430,7 @@ describe 'Client - specification' do
     NATS.start(opts) { NATS.stop }
   end
 
-  describe '#create_inbox' do
+  describe '#create_inbox', :jruby_excluded do
     it 'create the expected format' do
       expect(NATS.create_inbox).to match(/_INBOX\.[a-f0-9]{12}/)
     end

--- a/spec/client/client_spec.rb
+++ b/spec/client/client_spec.rb
@@ -98,7 +98,7 @@ describe 'Client - specification' do
     expect(sid).to_not eql(nil)
   end
 
-  it 'should receive a sid when doing a request', :jruby_excluded do
+  it 'should receive a sid when doing a request' do
     sid = nil
     errors = []
     with_em_timeout do
@@ -162,7 +162,7 @@ describe 'Client - specification' do
     expect(msgs.first).to eql('xxx')
   end
 
-  it 'should receive a response from a request', :jruby_excluded do
+  it 'should receive a response from a request' do
     received = false
     NATS.start do |nc|
       nc.subscribe('need_help') do |msg, reply|
@@ -179,7 +179,7 @@ describe 'Client - specification' do
     expect(received).to eql(true)
   end
 
-  it 'should perform similar using class mirror functions', :jruby_excluded do
+  it 'should perform similar using class mirror functions' do
     received = false
     NATS.start do
       s = NATS.subscribe('need_help') do |msg, reply|
@@ -243,7 +243,7 @@ describe 'Client - specification' do
     expect(received).to eql(true)
   end
 
-  it 'should allow proper request/reply across multiple connections', :jruby_excluded do
+  it 'should allow proper request/reply across multiple connections' do
     new_conn = nil
     received_request = false
     received_reply = false
@@ -430,7 +430,7 @@ describe 'Client - specification' do
     NATS.start(opts) { NATS.stop }
   end
 
-  describe '#create_inbox', :jruby_excluded do
+  describe '#create_inbox' do
     it 'create the expected format' do
       expect(NATS.create_inbox).to match(/_INBOX\.[a-f0-9]{12}/)
     end

--- a/spec/client/client_tls_spec.rb
+++ b/spec/client/client_tls_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Client - TLS spec' do
+describe 'Client - TLS spec', :jruby_excluded do
 
   context 'when server does not support TLS' do
 

--- a/spec/client/cluster_lb_spec.rb
+++ b/spec/client/cluster_lb_spec.rb
@@ -98,10 +98,12 @@ describe 'Client - cluster load balance' do
         clients.each do |c|
           servers[c.connected_server] += 1
           port, ip = Socket.unpack_sockaddr_in(c.get_peername)
-          port.should == URI(c.connected_server).port
+          expect(port).to eql(URI(c.connected_server).port)
         end
 
-        servers.each_value { |v| v.should > 0 }
+        servers.each_value do |v|
+          expect(v > 0).to eql(true)
+        end
         EM.stop
       end
     end

--- a/spec/client/cluster_multi_route_spec.rb
+++ b/spec/client/cluster_multi_route_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Client - cluster', :jruby_excluded do
+describe 'Client - cluster' do
 
   before(:all) do
     auth_options = {

--- a/spec/client/cluster_multi_route_spec.rb
+++ b/spec/client/cluster_multi_route_spec.rb
@@ -90,11 +90,11 @@ describe 'Client - cluster' do
       c1 = NATS.connect(:uri => @s1.uri)
       c2 = NATS.connect(:uri => @s2.uri)
       c1.subscribe('foo') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         received += 1
       end
       c2.subscribe('foo') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         received += 1
       end
       wait_on_routes_connected([c1, c2]) do
@@ -103,7 +103,7 @@ describe 'Client - cluster' do
         flush_routes([c1, c2]) { EM.stop }
       end
     end
-    received.should == 4
+    expect(received).to eql(4)
   end
 
   it 'should properly route messages with staggered startup' do
@@ -114,7 +114,7 @@ describe 'Client - cluster' do
     EM.run do
       c1 = NATS.connect(:uri => @s1.uri) do
         c1.subscribe('foo') do |msg|
-          msg.should == data
+          expect(msg).to eql(data)
           received += 1
         end
         c1.flush do
@@ -129,7 +129,6 @@ describe 'Client - cluster' do
         end
       end
     end
-    received.should == 2
+    expect(received).to eql(2)
   end
-
 end

--- a/spec/client/cluster_multi_route_spec.rb
+++ b/spec/client/cluster_multi_route_spec.rb
@@ -7,7 +7,7 @@ describe 'Client - cluster' do
       'user'     => 'derek',
       'password' => 'bella',
       'token'    => 'deadbeef',
-      'timeout'  => 1
+      'timeout'  => 5
     }
 
     s1_config_opts = {
@@ -48,7 +48,7 @@ describe 'Client - cluster' do
         authorization {
           user: '#{auth_options["user"]}'
           password: '#{auth_options["password"]}'
-          timeout: 0.5
+          timeout: #{auth_options["timeout"]}
         }
 
         cluster {
@@ -58,7 +58,7 @@ describe 'Client - cluster' do
           authorization {
             user: foo
             password: bar
-            timeout: 1
+            timeout: #{auth_options["timeout"]}
           }
 
           routes = [

--- a/spec/client/cluster_retry_connect_spec.rb
+++ b/spec/client/cluster_retry_connect_spec.rb
@@ -83,7 +83,7 @@ describe 'Client - cluster retry connect' do
     end
   end
 
-  it 'should re-establish asymmetric route connections upon restart' do
+  it 'should re-establish asymmetric route connections upon restart', :jruby_excluded do
     data = 'Hello World!'
     received = 0
     with_em_timeout(5) do |future|

--- a/spec/client/cluster_retry_connect_spec.rb
+++ b/spec/client/cluster_retry_connect_spec.rb
@@ -83,7 +83,7 @@ describe 'Client - cluster retry connect' do
     end
   end
 
-  it 'should re-establish asymmetric route connections upon restart', :jruby_excluded do
+  it 'should re-establish asymmetric route connections upon restart' do
     data = 'Hello World!'
     received = 0
     with_em_timeout(5) do |future|

--- a/spec/client/cluster_spec.rb
+++ b/spec/client/cluster_spec.rb
@@ -9,7 +9,7 @@ describe 'Client - cluster' do
       'user'     => 'derek',
       'password' => 'bella',
       'token'    => 'deadbeef',
-      'timeout'  => 1
+      'timeout'  => 5
     }
 
     s1_config_opts = {
@@ -50,7 +50,7 @@ describe 'Client - cluster' do
         authorization {
           user: '#{auth_options["user"]}'
           password: '#{auth_options["password"]}'
-          timeout: 1
+          timeout: #{auth_options["timeout"]}
         }
 
         cluster {
@@ -60,7 +60,7 @@ describe 'Client - cluster' do
           authorization {
             user: foo
             password: bar
-            timeout: 1
+            timeout: #{auth_options["timeout"]}
           }
 
           routes = [
@@ -102,11 +102,11 @@ describe 'Client - cluster' do
       c1 = NATS.connect(:uri => @s1.uri)
       c2 = NATS.connect(:uri => @s2.uri)
       c1.subscribe('foo') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         received += 1
       end
       c2.subscribe('foo') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         received += 1
       end
       wait_on_routes_connected([c1, c2]) do
@@ -115,7 +115,7 @@ describe 'Client - cluster' do
         flush_routes([c1, c2]) { EM.stop }
       end
     end
-    received.should == 4
+    expect(received).to eql(4)
   end
 
   it 'should properly route messages for distributed queues on different servers' do
@@ -126,12 +126,12 @@ describe 'Client - cluster' do
       c1 = NATS.connect(:uri => @s1.uri)
       c2 = NATS.connect(:uri => @s2.uri)
       c1.subscribe('foo', :queue => 'bar') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         c1_received += 1
         received += 1
       end
       c2.subscribe('foo', :queue => 'bar') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         c2_received += 1
         received += 1
       end
@@ -142,11 +142,11 @@ describe 'Client - cluster' do
       end
     end
 
-    received.should == to_send
-    c1_received.should be < to_send
-    c2_received.should be < to_send
-    c1_received.should be_within(25).of(to_send/2)
-    c2_received.should be_within(25).of(to_send/2)
+    expect(received).to eql(to_send)
+    expect(c1_received < to_send).to eql(true)
+    expect(c2_received < to_send).to eql(true)
+    expect(c1_received).to be_within(25).of(to_send/2)
+    expect(c2_received).to be_within(25).of(to_send/2)
   end
 
   it 'should properly route messages for distributed queues and normal subscribers on different servers' do
@@ -157,16 +157,16 @@ describe 'Client - cluster' do
       c1 = NATS.connect(:uri => @s1.uri)
       c2 = NATS.connect(:uri => @s2.uri)
       c1.subscribe('foo') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         received += 1
       end
       c1.subscribe('foo', :queue => 'bar') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         c1_received += 1
         received += 1
       end
       c2.subscribe('foo', :queue => 'bar') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         c2_received += 1
         received += 1
       end
@@ -177,11 +177,11 @@ describe 'Client - cluster' do
       end
     end
 
-    received.should == to_send*2 # queue subscriber + normal subscriber
-    c1_received.should be < to_send
-    c2_received.should be < to_send
-    c1_received.should be_within(15).of(to_send/2)
-    c2_received.should be_within(15).of(to_send/2)
+    expect(received).to eql(to_send*2) # queue subscriber + normal subscriber
+    expect(c1_received < to_send).to eql(true) 
+    expect(c2_received < to_send).to eql(true)
+    expect(c1_received).to be_within(15).of(to_send/2)
+    expect(c2_received).to be_within(15).of(to_send/2)
   end
 
   it 'should properly route messages for distributed queues with multiple groups on different servers' do
@@ -195,28 +195,28 @@ describe 'Client - cluster' do
       c2 = NATS.connect(:uri => @s2.uri)
 
       c1.subscribe('foo') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         received += 1
       end
       c1.subscribe('foo', :queue => 'bar') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         c1a_received += 1
-          received += 1
+        received += 1
       end
       c1.subscribe('foo', :queue => 'baz') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         c1b_received += 1
         received += 1
       end
 
       c2.subscribe('foo', :queue => 'bar') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         c2a_received += 1
         received += 1
       end
 
       c2.subscribe('foo', :queue => 'baz') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         c2b_received += 1
         received += 1
       end
@@ -228,11 +228,11 @@ describe 'Client - cluster' do
       end
     end
 
-    received.should == to_send*6 # 2 queue subscribers + normal subscriber * 2 pub loops
-    c1a_received.should be_within(25).of(to_send)
-    c2a_received.should be_within(25).of(to_send)
-    c1b_received.should be_within(25).of(to_send)
-    c2b_received.should be_within(25).of(to_send)
+    expect(received).to eql(to_send*6) # 2 queue subscribers + normal subscriber * 2 pub loops
+    expect(c1a_received).to be_within(25).of(to_send)
+    expect(c2a_received).to be_within(25).of(to_send)
+    expect(c1b_received).to be_within(25).of(to_send)
+    expect(c2b_received).to be_within(25).of(to_send)
   end
 
   it 'should properly route messages for distributed queues with reply subjects on different servers' do
@@ -244,12 +244,12 @@ describe 'Client - cluster' do
       c2 = NATS.connect(:uri => @s2.uri)
 
       c1.subscribe('foo', :queue => 'reply_test') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         c1_received += 1
         received += 1
       end
       c2.subscribe('foo', :queue => 'reply_test') do |msg|
-        msg.should == data
+        expect(msg).to eql(data)
         c2_received += 1
         received += 1
       end
@@ -259,11 +259,10 @@ describe 'Client - cluster' do
       end
     end
 
-    received.should == to_send
-    c1_received.should be < to_send
-    c2_received.should be < to_send
-    c1_received.should be_within(25).of(to_send/2)
-    c2_received.should be_within(25).of(to_send/2)
+    expect(received).to eql(to_send)
+    expect(c1_received < to_send).to eql(true)
+    expect(c2_received < to_send).to eql(true)
+    expect(c1_received).to be_within(25).of(to_send/2)
+    expect(c2_received).to be_within(25).of(to_send/2)
   end
-
 end

--- a/spec/client/cluster_spec.rb
+++ b/spec/client/cluster_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'yaml'
 
-describe 'Client - cluster' do
+describe 'Client - cluster', :jruby_excluded do
 
   before(:all) do
 

--- a/spec/client/cluster_spec.rb
+++ b/spec/client/cluster_spec.rb
@@ -95,29 +95,6 @@ describe 'Client - cluster' do
     end
   end
 
-  it 'should properly route plain messages between different servers' do
-    data = 'Hello World!'
-    received = 0
-    EM.run do
-      c1 = NATS.connect(:uri => @s1.uri)
-      c2 = NATS.connect(:uri => @s2.uri)
-      c1.subscribe('foo') do |msg|
-        expect(msg).to eql(data)
-        received += 1
-      end
-      c2.subscribe('foo') do |msg|
-        expect(msg).to eql(data)
-        received += 1
-      end
-      wait_on_routes_connected([c1, c2]) do
-        c2.publish('foo', data)
-        c2.publish('foo', data)
-        flush_routes([c1, c2]) { EM.stop }
-      end
-    end
-    expect(received).to eql(4)
-  end
-
   it 'should properly route messages for distributed queues on different servers' do
     data = 'Hello World!'
     to_send = 100

--- a/spec/client/cluster_spec.rb
+++ b/spec/client/cluster_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'yaml'
 
-describe 'Client - cluster', :jruby_excluded do
+describe 'Client - cluster' do
 
   before(:all) do
 

--- a/spec/client/error_on_client_spec.rb
+++ b/spec/client/error_on_client_spec.rb
@@ -6,11 +6,10 @@ describe 'Client - error on client' do
 
     it 'should show the contents of $1 when matched UNKNOWN' do
       EchoServer.start {
-        EM.reactor_running?.should be_truthy
-        NATS.on_error{|e|
+        expect(EM.reactor_running?).to eql(true)
+        NATS.on_error{ |e|
           # We use a CONNECT request to match Unknown Protocol
-          #e.to_s.should match(/\AUnknown Protocol: CONNECT\s+.*/i)
-          e.to_s.should match(/\AUnknown Protocol: CONNECT.+/i)
+          expect(e.to_s).to match(/\AUnknown Protocol: CONNECT.+/i)
 
           NATS.stop
           EchoServer.stop
@@ -30,7 +29,7 @@ describe 'Client - error on client' do
       closes = 0
 
       SilentServer.start {
-        EM.reactor_running?.should be_truthy
+        expect(EM.reactor_running?).to eql(true)
 
         NATS.on_error do |e|
           errors << e
@@ -48,7 +47,7 @@ describe 'Client - error on client' do
           :ping_interval => 1,
           :reconnect => false
         })
-        nc.should_receive(:queue_server_rt).exactly(2).times
+        expect(nc).to receive(:queue_server_rt).exactly(2).times
       }
 
       expect(nc.connected?).to be_falsey

--- a/spec/client/fast_producer_spec.rb
+++ b/spec/client/fast_producer_spec.rb
@@ -12,8 +12,8 @@ describe 'Client - fast producer' do
   end
 
   it 'should report the maximum outbound threshold' do
-    NATS::FAST_PRODUCER_THRESHOLD.should_not be_nil
-    NATS::FAST_PRODUCER_THRESHOLD.should == (10*1024*1024)
+    expect(NATS::FAST_PRODUCER_THRESHOLD).to_not eql(nil)
+    expect(NATS::FAST_PRODUCER_THRESHOLD).to eql(10*1024*1024)
   end
 
   it 'should report the outstanding bytes pending' do
@@ -22,7 +22,7 @@ describe 'Client - fast producer' do
     proto = "PUB foo  #{data.size}\r\n#{data}\r\n"
     NATS.start do
       (1..100).each { NATS.publish('foo', data) }
-      NATS.pending_data_size.should == (100*proto.size)
+      expect(NATS.pending_data_size).to eql(100*proto.size)
       NATS.stop
     end
   end

--- a/spec/client/queues_spec.rb
+++ b/spec/client/queues_spec.rb
@@ -15,12 +15,12 @@ describe "Client - queue group support" do
     received = 0
     NATS.start do
       s1 = NATS.subscribe('foo', :queue => 'g1') { received += 1 }
-      s1.should_not be_nil
+      expect(s1).to_not eql(nil)
       s2 = NATS.subscribe('foo', :queue => 'g1') { received += 1 }
-      s2.should_not be_nil
+      expect(s2).to_not eql(nil)
       NATS.publish('foo', 'hello') { NATS.stop }
     end
-    received.should == 1
+    expect(received).to eql(1)
   end
 
   it "should allow queue receivers and normal receivers to work together" do
@@ -30,7 +30,7 @@ describe "Client - queue group support" do
       NATS.subscribe('foo') { received += 1 }
       NATS.publish('foo', 'hello') { NATS.stop }
     end
-    received.should == 2
+    expect(received).to eql(2)
   end
 
   it "should spread messages equally across multiple receivers" do
@@ -50,8 +50,10 @@ describe "Client - queue group support" do
       (0...TOTAL).each { NATS.publish('foo.bar', 'ok') }
       NATS.flush { NATS.stop }
     end
-    received.each_value { |count| (AVG - count).abs.should < ALLOWED_V }
-    total.should == TOTAL
+    received.each_value do |count|
+      expect((AVG - count).abs < ALLOWED_V).to eql(true)
+    end
+    expect(total).to eql(TOTAL)
   end
 
   it "should deliver a message to only one subscriber in a queue group, regardless of wildcard subjects" do
@@ -62,7 +64,7 @@ describe "Client - queue group support" do
       NATS.subscribe('foo.>', :queue => 'g1') { received += 1 }
       NATS.publish('foo.bar', 'hello') { NATS.stop }
     end
-    received.should == 1
+    expect(received).to eql(1)
   end
 
   it "should deliver 1 message/group for each publish" do
@@ -79,8 +81,8 @@ describe "Client - queue group support" do
       end
       NATS.flush { NATS.stop }
     end
-    received_g1.should == 10
-    received_g2.should == 10
+    expect(received_g1).to eql(10)
+    expect(received_g2).to eql(10)
   end
 
   it "should re-establish queue groups on reconnect" do
@@ -141,6 +143,8 @@ describe "Client - queue group support" do
     # message) of .5 in the two subscriber case. This verifies that the receive
     # count of each subscriber is within 3 standard deviations of the mean.
     # In theory, this means that the test will fail ~ .3% of the time.
-    buckets.values.each { |msg_count| msg_count.should be_within(150).of(500) }
+    buckets.values.each do |msg_count|
+      expect(msg_count).to be_within(150).of(500)
+    end
   end
 end

--- a/spec/client/reconnect_spec.rb
+++ b/spec/client/reconnect_spec.rb
@@ -26,8 +26,8 @@ describe 'Client - reconnect specification' do
 
   it 'should properly report connected after connect callback' do
     NATS.start do
-      NATS.connected?.should be_truthy
-      NATS.reconnecting?.should be_falsey
+      expect(NATS.connected?).to eql(true)
+      expect(NATS.reconnecting?).to eql(false)
       NATS.stop
     end
   end
@@ -68,6 +68,6 @@ describe 'Client - reconnect specification' do
       }
     end
 
-    received.should be_truthy
+    expect(received).to eql(true)
   end
 end

--- a/spec/client/server_info_spec.rb
+++ b/spec/client/server_info_spec.rb
@@ -12,22 +12,22 @@ describe 'Client - server_info support' do
   end
 
   it 'should report nil when not connected for server_info' do
-    NATS.connected?.should be_falsey
-    NATS.server_info.should be_nil
+    expect(NATS.connected?).to eql(false)
+    expect(NATS.server_info).to eql(nil)
   end
 
   it 'should report the appropriate server_info for connected clients' do
     NATS.start do
       info = NATS.server_info
-      info.should_not be_nil
-      info.should be_an_instance_of Hash
-      info.should have_key :server_id
-      info.should have_key :version
-      info.should have_key :auth_required
-      info.should have_key :ssl_required
-      info.should have_key :max_payload
-      info.should have_key :host
-      info.should have_key :port
+      expect(info).to_not eql(nil)
+      expect(info).to be_a Hash
+      expect(info).to have_key :server_id
+      expect(info).to have_key :version
+      expect(info).to have_key :auth_required
+      expect(info).to have_key :ssl_required
+      expect(info).to have_key :max_payload
+      expect(info).to have_key :host
+      expect(info).to have_key :port
       NATS.stop
     end
   end
@@ -35,17 +35,16 @@ describe 'Client - server_info support' do
   it 'should report server info for individual connections' do
     NATS.start do
       info = NATS.client.server_info
-      info.should_not be_nil
-      info.should be_an_instance_of Hash
-      info.should have_key :server_id
-      info.should have_key :version
-      info.should have_key :auth_required
-      info.should have_key :ssl_required
-      info.should have_key :max_payload
-      info.should have_key :host
-      info.should have_key :port
+      expect(info).to_not be(nil)
+      expect(info).to be_a Hash
+      expect(info).to have_key :server_id
+      expect(info).to have_key :version
+      expect(info).to have_key :auth_required
+      expect(info).to have_key :ssl_required
+      expect(info).to have_key :max_payload
+      expect(info).to have_key :host
+      expect(info).to have_key :port
       NATS.stop
     end
   end
-
 end

--- a/spec/client/sub_timeouts_spec.rb
+++ b/spec/client/sub_timeouts_spec.rb
@@ -20,7 +20,7 @@ describe 'Client - subscriptions with timeouts' do
       NATS.timeout(sid, TIMEOUT)
       EM.add_timer(WAIT) { NATS.publish('foo') { NATS.stop } }
     end
-    received.should == 0
+    expect(received).to eql(0)
   end
 
   it "a subscription should call the timeout callback if no messages are received" do
@@ -31,8 +31,8 @@ describe 'Client - subscriptions with timeouts' do
       NATS.timeout(sid, TIMEOUT) { timeout_recvd = true }
       EM.add_timer(WAIT) { NATS.stop }
     end
-    timeout_recvd.should be_truthy
-    received.should == 0
+    expect(timeout_recvd).to eql(true)
+    expect(received).to eql(0)
   end
 
   it "a subscription should call the timeout callback if no messages are received, connection version" do
@@ -43,8 +43,8 @@ describe 'Client - subscriptions with timeouts' do
       c.timeout(sid, TIMEOUT) { timeout_recvd = true }
       EM.add_timer(WAIT) { NATS.stop }
     end
-    timeout_recvd.should be_truthy
-    received.should == 0
+    expect(timeout_recvd).to eql(true)
+    expect(received).to eql(0)
   end
 
   it "a subscription should not call the timeout callback if a message is received" do
@@ -57,8 +57,8 @@ describe 'Client - subscriptions with timeouts' do
       NATS.publish('foo')
       EM.add_timer(WAIT) { NATS.stop }
     end
-    timeout_recvd.should be_falsey
-    received.should == 2
+    expect(timeout_recvd).to eql(false)
+    expect(received).to eql(2)
   end
 
   it "a subscription should not call the timeout callback if a correct # messages are received" do
@@ -71,8 +71,8 @@ describe 'Client - subscriptions with timeouts' do
       NATS.publish('foo')
       EM.add_timer(WAIT) { NATS.stop }
     end
-    timeout_recvd.should be_falsey
-    received.should == 2
+    expect(timeout_recvd).to eql(false)
+    expect(received).to eql(2)
   end
 
   it "a subscription should call the timeout callback if a correct # messages are not received" do
@@ -84,8 +84,8 @@ describe 'Client - subscriptions with timeouts' do
       NATS.publish('foo')
       EM.add_timer(WAIT) { NATS.publish('foo') { NATS.stop} }
     end
-    timeout_recvd.should be_truthy
-    received.should == 1
+    expect(timeout_recvd).to eql(true)
+    expect(received).to eql(1)
   end
 
   it "a subscription should call the timeout callback and message callback if requested" do
@@ -96,8 +96,7 @@ describe 'Client - subscriptions with timeouts' do
       NATS.timeout(sid, TIMEOUT, :auto_unsubscribe => false) { timeout_recvd = true }
       EM.add_timer(WAIT) { NATS.publish('foo') { NATS.stop} }
     end
-    timeout_recvd.should be_truthy
-    received.should == 1
+    expect(timeout_recvd).to eql(true)
+    expect(received).to eql(1)
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -141,7 +141,7 @@ class NatsServerControl
       system("gnatsd #{args} 2> /dev/null &")
     end
     exitstatus = $?.exitstatus
-    NATS.wait_for_server(@uri, 10) if wait_for_server
+    NATS.wait_for_server(@uri, 10) if wait_for_server # jruby can be slow on startup...
     exitstatus
   end
 


### PR DESCRIPTION
- Adds testing Java 7 and Java 8 under oraclejdk and openjdk

- Skip specs which generate inboxes in jruby, pending for now since low performant in CI environment (https://github.com/jruby/jruby/issues/3351)

- Also skip TLS specs in jruby since failing and need more tweaks :/

- Updates usage of rspec throughout

- Add profiling of tests to rspec to detect slow tests
