### PR TITLE
Add Time based reconnect backoff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,35 +21,33 @@ bundler_args: --without server
 matrix:
   include:
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom' EVENTMACHINE_LIBRARY="pure_ruby"
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       script: "bundle exec rake spec:client:jruby"
       jdk: openjdk7
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom' EVENTMACHINE_LIBRARY="pure_ruby"
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       script: "bundle exec rake spec:client:jruby"
       jdk: oraclejdk7
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom' EVENTMACHINE_LIBRARY="pure_ruby"
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       script: "bundle exec rake spec:client:jruby"
       jdk: openjdk8
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom' EVENTMACHINE_LIBRARY="pure_ruby"
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       script: "bundle exec rake spec:client:jruby"
       jdk: oraclejdk8
-    - rvm: 2.3.2
-      env: EVENTMACHINE_LIBRARY="pure_ruby"
   allow_failures:
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom' EVENTMACHINE_LIBRARY="pure_ruby"
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       jdk: openjdk7
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom' EVENTMACHINE_LIBRARY="pure_ruby"
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       jdk: oraclejdk7
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom' EVENTMACHINE_LIBRARY="pure_ruby"
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       jdk: openjdk8
     - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom' EVENTMACHINE_LIBRARY="pure_ruby"
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false' JAVA_OPTS='-Djava.security.egd=file:///dev/urandom'
       jdk: oraclejdk8
     - rvm: ruby-head
     - rvm: 2.4.0-preview1

--- a/spec/client/client_cluster_config_spec.rb
+++ b/spec/client/client_cluster_config_spec.rb
@@ -132,11 +132,11 @@ describe 'Client - cluster config' do
 
   it 'should fail if server is available but does not have proper auth' do
     errors = []
-    with_em_timeout do
+    with_em_timeout(5) do
       NATS.on_error do |e|
         errors << e
       end
-      NATS.connect(:uri => ['nats://127.0.0.1:4224', "nats://127.0.0.1:#{CLUSTER_AUTH_PORT}"])
+      NATS.connect(:uri => ['nats://127.0.0.1:4224', "nats://127.0.0.1:#{CLUSTER_AUTH_PORT}"], :dont_randomize_servers => true)
     end
     expect(errors.count).to eql(2)
     expect(errors.first).to be_a(NATS::AuthError)

--- a/spec/client/client_tls_spec.rb
+++ b/spec/client/client_tls_spec.rb
@@ -676,7 +676,7 @@ describe 'Client - TLS spec', :jruby_excluded do
           nc = NATS.connect(options) do |conn|
             connects += 1
           end
-        end.to raise_error
+        end.to raise_error(NATS::Error)
       end
       expect(errors.count).to eql(0)
       expect(disconnects).to eql(0)
@@ -725,7 +725,7 @@ describe 'Client - TLS spec', :jruby_excluded do
           nc = NATS.connect(options) do |conn|
             connects += 1
           end
-        end.to raise_error
+        end.to raise_error(NATS::Error)
       end
 
       # No error here since it fails synchronously


### PR DESCRIPTION
Current logic can make the client try to reconnect nonstop very fast until exhausting reconnect attempts when there are exceptions during when trying to establish a connections.

Fixes #138 