### PR TITLE
Control Nats Connection Name via ENV var

### DIFF
--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -112,6 +112,8 @@ module NATS
       opts[:ssl] = ENV['NATS_SSL'].downcase == 'true' unless ENV['NATS_SSL'].nil?
       opts[:max_reconnect_attempts] = ENV['NATS_MAX_RECONNECT_ATTEMPTS'].to_i unless ENV['NATS_MAX_RECONNECT_ATTEMPTS'].nil?
       opts[:reconnect_time_wait] = ENV['NATS_RECONNECT_TIME_WAIT'].to_i unless ENV['NATS_RECONNECT_TIME_WAIT'].nil?
+      opts[:name] ||= ENV['NATS_CONNECTION_NAME']
+
 
       opts[:ping_interval] = ENV['NATS_PING_INTERVAL'].to_i unless ENV['NATS_PING_INTERVAL'].nil?
       opts[:max_outstanding_pings] = ENV['NATS_MAX_OUTSTANDING_PINGS'].to_i unless ENV['NATS_MAX_OUTSTANDING_PINGS'].nil?

--- a/spec/client/client_spec.rb
+++ b/spec/client/client_spec.rb
@@ -30,6 +30,13 @@ describe 'Client - specification' do
     expect(NATS.connected?).to eql(false)
   end
 
+  it 'should report supplied connection name' do
+    NATS.start(uri: 'nats://127.0.0.1:4222', name: 'test-connection') do
+      expect(JSON.parse(Net::HTTP.get(URI('http://localhost:8222/connz')))['connections'][0]['name']).to eq 'test-connection'
+      NATS.stop
+    end
+  end
+
   it 'should perform basic block start and stop' do
     NATS.start { NATS.stop }
   end

--- a/spec/client/client_spec.rb
+++ b/spec/client/client_spec.rb
@@ -31,6 +31,8 @@ describe 'Client - specification' do
   end
 
   it 'should report supplied connection name' do
+    @s.kill_server
+    @s.start_server(true, monitoring: true)
     NATS.start(uri: 'nats://127.0.0.1:4222', name: 'test-connection') do
       expect(JSON.parse(Net::HTTP.get(URI('http://localhost:8222/connz')))['connections'][0]['name']).to eq 'test-connection'
       NATS.stop

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
-
 $:.unshift('./lib')
+
+require 'net/http'
 require 'nats/client'
 require 'tempfile'
 
@@ -131,6 +132,7 @@ class NatsServerControl
     @pid = nil
 
     args = "-p #{@uri.port} -P #{@pid_file}"
+    args += " -m 8222"
     args += " --user #{@uri.user}" if @uri.user
     args += " --pass #{@uri.password}" if @uri.password
     args += " #{@flags}" if @flags

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -124,7 +124,7 @@ class NatsServerControl
     rss = (parts[1].to_i)/1024
   end
 
-  def start_server(wait_for_server=true)
+  def start_server(wait_for_server=true, monitoring: false)
     if NATS.server_running? @uri
       @was_running = true
       return 0
@@ -132,7 +132,7 @@ class NatsServerControl
     @pid = nil
 
     args = "-p #{@uri.port} -P #{@pid_file}"
-    args += " -m 8222"
+    args += " -m 8222" if monitoring
     args += " --user #{@uri.user}" if @uri.user
     args += " --pass #{@uri.password}" if @uri.password
     args += " #{@flags}" if @flags


### PR DESCRIPTION
In order to test our Datadog Integration with gnatsd - we need to be able to control the name of the connection from the `nats-sub` and `nats-pub` CLI tools.  In keeping with the rest of the options, we've made that configurable via an ENV var.