### PR TITLE
New Request/Response implementation using Fibers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nats (0.8.4)
+    nats (0.9.0)
       eventmachine (~> 1.2, >= 1.2)
 
 GEM
@@ -43,4 +43,4 @@ DEPENDENCIES
   thin
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ end
 NATS.connect { NATS.publish('test', 'Hello World!') }
 ```
 
+See examples and benchmarks for more information..
+
 ### TLS
 
 Advanced customizations options for setting up a secure connection can
@@ -210,7 +212,76 @@ NATS.start(options) do |nats|
 end
 ```
 
-See examples and benchmarks for more information..
+### Fibers
+
+Requests without a callback can be made to work synchronously and return 
+the result when running in a Fiber.  For these type of requests, it is
+possible to set a timeout of how long to wait for a single or multiple
+responses.
+
+```ruby
+NATS.start {
+
+  NATS.subscribe('help') do |msg, reply|
+    puts "[Received]: <<- #{msg}"
+    NATS.publish(reply, "I'll help! - #{msg}")
+  end
+
+  NATS.subscribe('slow') do |msg, reply|
+    puts "[Received]: <<- #{msg}"
+    EM.add_timer(1) { NATS.publish(reply, "I'll help! - #{msg}") }
+  end
+
+  10.times do |n|
+    NATS.subscribe('hi') do |msg, reply|
+      NATS.publish(reply, "Hello World! - id:#{n}")
+    end
+  end
+
+  Fiber.new do
+    # Requests work synchronously within the same Fiber
+    # returning the message when done.
+    response = NATS.request('help', 'foo')
+    puts "[Response]: ->> '#{response}'"
+
+    # Specifying a custom timeout to give up waiting for
+    # a response.
+    response = NATS.request('slow', 'bar', timeout: 2)
+    if response.nil?
+      puts "No response after 2 seconds..."
+    else
+      puts "[Response]: ->> '#{response}'"
+    end
+
+    # Can gather multiple responses with the same request
+    # which will then return a collection with the responses
+    # that were received before the timeout.
+    responses = NATS.request('hi', 'quux', max: 10, timeout: 1)
+    responses.each_with_index do |response, i|
+      puts "[Response# #{i}]: ->> '#{response}'"
+    end
+    
+    # If no replies then an empty collection is returned.
+    responses = NATS.request('nowhere', '', max: 10, timeout: 2)
+    if responses.any?
+      puts "Got #{responses.count} responses"
+    else
+      puts "No response after 2 seconds..."
+    end
+
+    NATS.stop
+  end.resume
+
+  # Multiple fibers can make requests concurrently
+  # under the same Eventmachine loop.
+  Fiber.new do
+    10.times do |n|
+      response = NATS.request('help', "help.#{n}")
+      puts "[Response]: ->> '#{response}'"
+    end
+  end.resume
+}
+```
 
 ## License
 

--- a/examples/fiber_request.rb
+++ b/examples/fiber_request.rb
@@ -1,0 +1,68 @@
+require 'fiber'
+require 'nats/client'
+
+["TERM", "INT"].each { |sig| trap(sig) { EM.stop } }
+
+NATS.on_error { |err| puts "Server Error: #{err}"; exit! }
+
+NATS.start {
+
+  NATS.subscribe('help') do |msg, reply|
+    puts "[Received]: <<- #{msg}"
+    NATS.publish(reply, "I'll help! - #{msg}")
+  end
+
+  NATS.subscribe('slow') do |msg, reply|
+    puts "[Received]: <<- #{msg}"
+    EM.add_timer(1) { NATS.publish(reply, "I'll help! - #{msg}") }
+  end
+
+  10.times do |n|
+    NATS.subscribe('hi') do |msg, reply|
+      NATS.publish(reply, "Hello World! - id:#{n}")
+    end
+  end
+
+  Fiber.new do
+    # Requests work synchronously within the same Fiber
+    # returning the message when done.
+    response = NATS.request('help', 'foo')
+    puts "[Response]: ->> '#{response}'"
+
+    # Specifying a custom timeout to give up waiting for
+    # a response.
+    response = NATS.request('slow', 'bar', timeout: 2)
+    if response.nil?
+      puts "No response after 2 seconds..."
+    else
+      puts "[Response]: ->> '#{response}'"
+    end
+
+    # Can gather multiple responses with the same request
+    # which will then return a collection with the responses
+    # that were received before the timeout.
+    responses = NATS.request('hi', 'quux', max: 10, timeout: 1)
+    responses.each_with_index do |response, i|
+      puts "[Response# #{i}]: ->> '#{response}'"
+    end
+    
+    # If no replies then an empty collection is returned.
+    responses = NATS.request('nowhere', '', max: 10, timeout: 2)
+    if responses.any?
+      puts "Got #{responses.count} responses"
+    else
+      puts "No response after 2 seconds..."
+    end
+
+    NATS.stop
+  end.resume
+
+  # Multiple fibers can make requests concurrently
+  # under the same Eventmachine loop.
+  Fiber.new do
+    10.times do |n|
+      response = NATS.request('help', "help.#{n}")
+      puts "[Response]: ->> '#{response}'"
+    end
+  end.resume
+}

--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -22,6 +22,7 @@ require "#{ep}/ext/em"
 require "#{ep}/ext/bytesize"
 require "#{ep}/ext/json"
 require "#{ep}/version"
+require "#{ep}/nuid"
 
 module NATS
 
@@ -374,6 +375,7 @@ module NATS
     @tls = nil
     @tls = options[:tls] if options[:tls]
     @ssl = options[:ssl] if options[:ssl] or @tls
+    @nuid = NATS::NUID.new
 
     send_connect_command
   end
@@ -460,7 +462,7 @@ module NATS
   # @return [Object] sid
   def request(subject, data=nil, opts={}, &cb)
     return unless subject
-    inbox = NATS.create_inbox
+    inbox = @nuid.next
     s = subscribe(inbox, opts) { |msg, reply|
       case cb.arity
         when 0 then cb.call

--- a/lib/nats/nuid.rb
+++ b/lib/nats/nuid.rb
@@ -1,0 +1,72 @@
+# Copyright 2016-2018 The NATS Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'securerandom'
+
+module NATS
+  class NUID
+    DIGITS = [*'0'..'9', *'A'..'Z', *'a'..'z']
+    BASE          = 62
+    PREFIX_LENGTH = 12
+    SEQ_LENGTH    = 10
+    TOTAL_LENGTH  = PREFIX_LENGTH + SEQ_LENGTH
+    MAX_SEQ       = BASE**10
+    MIN_INC       = 33
+    MAX_INC       = 333
+    INC = MAX_INC - MIN_INC
+
+    def initialize
+      @prand    = Random.new
+      @seq      = @prand.rand(MAX_SEQ)
+      @inc      = MIN_INC + @prand.rand(INC)
+      @prefix   = ''
+      randomize_prefix!
+    end
+
+    def next
+      @seq += @inc
+      if @seq >= MAX_SEQ
+        randomize_prefix!
+        reset_sequential!
+      end
+      l = @seq
+
+      # Do this inline 10 times to avoid even more extra allocs,
+      # then use string interpolation of everything which works
+      # faster for doing concat.
+      s_10 = DIGITS[l % BASE];
+
+      # Ugly, but parallel assignment is slightly faster here...
+      s_09, s_08, s_07, s_06, s_05, s_04, s_03, s_02, s_01 = \
+      (l /= BASE; DIGITS[l % BASE]), (l /= BASE; DIGITS[l % BASE]), (l /= BASE; DIGITS[l % BASE]),\
+      (l /= BASE; DIGITS[l % BASE]), (l /= BASE; DIGITS[l % BASE]), (l /= BASE; DIGITS[l % BASE]),\
+      (l /= BASE; DIGITS[l % BASE]), (l /= BASE; DIGITS[l % BASE]), (l /= BASE; DIGITS[l % BASE])
+      "#{@prefix}#{s_01}#{s_02}#{s_03}#{s_04}#{s_05}#{s_06}#{s_07}#{s_08}#{s_09}#{s_10}"
+    end
+
+    def randomize_prefix!
+      @prefix = \
+      SecureRandom.random_bytes(PREFIX_LENGTH).each_byte
+        .reduce('') do |prefix, n|
+        prefix << DIGITS[n % BASE]
+      end
+    end
+
+    private
+
+    def reset_sequential!
+      @seq = @prand.rand(MAX_SEQ)
+      @inc = MIN_INC + @prand.rand(INC)
+    end
+  end
+end

--- a/lib/nats/version.rb
+++ b/lib/nats/version.rb
@@ -14,7 +14,7 @@
 
 module NATS
   # NOTE: These are all announced to the server on CONNECT
-  VERSION = "0.8.4".freeze
+  VERSION = "0.9.0".freeze
   LANG    = RUBY_ENGINE
   PROTOCOL_VERSION = 1
 end

--- a/nats.gemspec
+++ b/nats.gemspec
@@ -24,7 +24,6 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://nats.io'
   s.description = 'NATS is an open-source, high-performance, lightweight cloud messaging system.'
   s.licenses = ['MIT']
-  s.has_rdoc = true
 
   s.authors = ['Derek Collison']
   s.email = ['derek.collison@gmail.com']

--- a/nats.gemspec
+++ b/nats.gemspec
@@ -47,6 +47,7 @@ spec = Gem::Specification.new do |s|
     bin/nats-top
     bin/nats-request
     lib/nats/client.rb
+    lib/nats/nuid.rb
     lib/nats/version.rb
     lib/nats/ext/bytesize.rb
     lib/nats/ext/em.rb

--- a/spec/client/client_requests_spec.rb
+++ b/spec/client/client_requests_spec.rb
@@ -1,0 +1,143 @@
+require 'spec_helper'
+
+describe 'Client - Requests using fibers' do
+
+  before(:each) do
+    @s = NatsServerControl.new
+    @s.start_server(true)
+  end
+
+  after(:each) do
+    @s.kill_server
+  end
+
+  it 'should receive a response from a request' do
+    received = false
+    NATS.start do |nc|
+      nc.subscribe('need_help') do |msg, reply|
+        expect(msg).to eql('yyy')
+        nc.publish(reply, 'help')
+      end
+
+      Fiber.new do
+        response = nc.request('need_help', 'yyy')
+        received = true
+        expect(response).to eql('help')
+        NATS.stop
+      end.resume
+
+      timeout_nats_on_failure
+    end
+    expect(received).to eql(true)
+  end
+
+  it 'should perform similar using class mirror functions' do
+    received = false
+    NATS.start do
+      s = NATS.subscribe('need_help') do |msg, reply|
+        expect(msg).to eql('yyy')
+        NATS.publish(reply, 'help')
+        NATS.unsubscribe(s)
+      end
+
+      Fiber.new do
+        response = NATS.request('need_help', 'yyy')
+        received = true
+        expect(response).to eql('help')
+        NATS.stop
+      end.resume
+
+      timeout_nats_on_failure
+    end
+    expect(received).to eql(true)
+  end
+
+  it 'should be possible to gather multiple responses before a timeout' do
+    responses = []
+    NATS.start do |nc|
+      10.times do |n|
+        nc.subscribe('need_help') do |msg, reply|
+          expect(msg).to eql('yyy')
+          nc.publish(reply, "help-#{n}")
+        end
+      end
+
+      Fiber.new do
+        responses = nc.request('need_help', 'yyy', max: 5, timeout: 1)
+        NATS.stop
+      end.resume
+
+      timeout_nats_on_failure
+    end
+    expect(responses.count).to eql(5)
+    responses.each_with_index do |response, i|
+      expect(response).to eql("help-#{i}")
+    end
+  end
+
+  it 'should be possible to gather as many responses as possible before the timeout' do
+    responses = []
+    NATS.start do |nc|
+      nc.subscribe('need_help') do |msg, reply|
+        3.times do |n|
+          nc.publish(reply, "help-#{n}")
+        end
+
+        EM.add_timer(1) do
+          3.upto(10).each do |n|
+            nc.publish(reply, "help-#{n}")
+          end
+        end
+      end
+
+      Fiber.new do
+        responses = nc.request('need_help', 'yyy', max: 5, timeout: 0.5)
+        NATS.stop
+      end.resume
+
+      timeout_nats_on_failure(2)
+    end
+
+    # Expected 5 but only 3 made it.
+    expect(responses.count).to eql(3)
+    responses.each_with_index do |response, i|
+      expect(response).to eql("help-#{i}")
+    end
+  end
+
+  it 'should return empty array in case waited many responses but got none before timeout' do
+    responses = []
+    NATS.start do |nc|
+      Fiber.new do
+        responses = nc.request('need_help', 'yyy', max: 5, timeout: 0.5)
+        NATS.stop
+      end.resume
+
+      timeout_nats_on_failure(2)
+    end
+
+    expect(responses.count).to eql(0)
+  end
+
+  it 'should return nil in case waited single response but got none before timeout' do
+    response = nil
+    NATS.start do |nc|
+      Fiber.new do
+        response = nc.request('need_help', 'yyy')
+        NATS.stop
+      end.resume
+
+      timeout_nats_on_failure(2)
+    end
+    expect(response).to eql(nil)
+  end
+  
+  it 'should fail if not wrapped in a fiber' do
+    NATS.start do
+      expect do
+        NATS.request('need_help', 'yyy')
+      end.to raise_error(FiberError)
+      NATS.stop
+    end
+  end  
+end

--- a/spec/client/client_spec.rb
+++ b/spec/client/client_spec.rb
@@ -115,7 +115,7 @@ describe 'Client - specification' do
         errors << e
       end
       NATS.start do |nc|
-        sid = nc.request('foo')
+        sid = nc.request('foo') { }
       end
     end
     expect(sid).to_not eql(nil)

--- a/spec/client/nuid_spec.rb
+++ b/spec/client/nuid_spec.rb
@@ -1,0 +1,60 @@
+# Copyright 2016-2018 The NATS Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe 'NUID' do
+  it "should have a fixed length and be unique" do
+    nuid = NATS::NUID.new
+    entries = []
+    total = 500_000
+    total.times do
+      entry = nuid.next
+      expect(entry.size).to eql(NATS::NUID::TOTAL_LENGTH)
+      entries << entry
+    end
+    entries.uniq!
+    expect(entries.count).to eql(total)
+  end
+
+  it "should be unique after 1M entries" do
+    total = 1_000_000
+    entries = []
+    nuid = NATS::NUID.new
+    total.times do
+      entries << nuid.next
+    end
+    entries.uniq!
+    expect(entries.count).to eql(total)
+  end
+
+  it "should randomize the prefix after sequence is done" do
+    nuid = NATS::NUID.new
+    seq_a = nuid.instance_variable_get('@seq')
+    inc_a = nuid.instance_variable_get('@inc')
+    a = nuid.next
+
+    seq_b = nuid.instance_variable_get('@seq')
+    inc_b = nuid.instance_variable_get('@inc')
+    expect(seq_a < seq_b).to eql(true)
+    expect(seq_b).to eql(seq_a + inc_a)
+    b = nuid.next
+
+    nuid.instance_variable_set('@seq', NATS::NUID::MAX_SEQ+1)
+    c = nuid.next
+    l = NATS::NUID::PREFIX_LENGTH
+    expect(a[0..l]).to eql(b[0..l])
+    expect(a[0..l]).to_not eql(c[0..l])
+  end
+end

--- a/spec/client/server_info_spec.rb
+++ b/spec/client/server_info_spec.rb
@@ -24,7 +24,7 @@ describe 'Client - server_info support' do
       expect(info).to have_key :server_id
       expect(info).to have_key :version
       expect(info).to have_key :auth_required
-      expect(info).to have_key :ssl_required
+      expect(info).to have_key :tls_required
       expect(info).to have_key :max_payload
       expect(info).to have_key :host
       expect(info).to have_key :port
@@ -40,7 +40,7 @@ describe 'Client - server_info support' do
       expect(info).to have_key :server_id
       expect(info).to have_key :version
       expect(info).to have_key :auth_required
-      expect(info).to have_key :ssl_required
+      expect(info).to have_key :tls_required
       expect(info).to have_key :max_payload
       expect(info).to have_key :host
       expect(info).to have_key :port


### PR DESCRIPTION
- Add new Fiber-aware `request` that works synchronously under the same fiber, using the new request/response implementation that is  less chatty over the network and uses a single async subscription.

- Introduce NUID style inboxes for requests

- Spec updates