### PR TITLE
Support for no echo option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nats (0.9.2)
+    nats (0.10.0)
       eventmachine (~> 1.2, >= 1.2)
 
 GEM

--- a/lib/nats/version.rb
+++ b/lib/nats/version.rb
@@ -14,7 +14,7 @@
 
 module NATS
   # NOTE: These are all announced to the server on CONNECT
-  VERSION = "0.9.2".freeze
+  VERSION = "0.10.0".freeze
   LANG    = RUBY_ENGINE
   PROTOCOL_VERSION = 1
 end

--- a/spec/client/client_connect_spec.rb
+++ b/spec/client/client_connect_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+describe 'Client - Connect' do
+
+  before(:each) do
+    @s = NatsServerControl.new
+    @s.start_server(true)
+  end
+
+  after(:each) do
+    @s.kill_server
+  end
+
+  context "No echo support" do
+    it "should not receive messages when no echo is enabled" do
+      errors = []
+      msgs_a = []
+      msgs_b = []
+      with_em_timeout do
+        NATS.on_error do |e|
+          p e
+          errors << e
+        end
+
+        # Client A will receive all messages from B
+        NATS.connect(uri: @s.uri, no_echo: true) do |nc|
+          nc.subscribe("hello") do |msg|
+            msgs_a << msg
+          end
+
+          EM.add_timer(0.5) do
+            10.times do
+              nc.publish("hello", "world")
+            end
+          end
+        end
+
+        # Default is classic behavior of client which is
+        # for echo to be enabled, so will receive messages
+        # from Client A and itself.
+        NATS.connect(uri: @s.uri) do |nc|
+          nc.subscribe("hello") do |msg|
+            msgs_b << msg
+          end
+
+          EM.add_timer(0.5) do
+            10.times do
+              nc.publish("hello", "world")
+            end
+          end
+        end
+      end
+
+      expect(errors.count).to eql(0)
+      expect(msgs_a.count).to eql(10)
+      expect(msgs_b.count).to eql(20)
+    end
+
+    it "should have no echo enabled by default" do
+      errors = []
+      msgs_a = []
+      msgs_b = []
+      with_em_timeout do
+        NATS.on_error do |e|
+          errors << e
+        end
+
+        # Client A will receive all messages from B
+        NATS.connect(uri: @s.uri) do |nc|
+          nc.subscribe("hello") do |msg|
+            msgs_a << msg
+          end
+
+          EM.add_timer(0.5) do
+            10.times do
+              nc.publish("hello", "world")
+            end
+          end
+        end
+
+        # Default is classic behavior of client which is
+        # for echo to be enabled, so will receive messages
+        # from Client A and itself.
+        NATS.connect(uri: @s.uri) do |nc|
+          nc.subscribe("hello") do |msg|
+            msgs_b << msg
+          end
+
+          EM.add_timer(0.5) do
+            10.times do
+              nc.publish("hello", "world")
+            end
+          end
+        end
+      end
+
+      expect(errors.count).to eql(0)
+      expect(msgs_a.count).to eql(20)
+      expect(msgs_b.count).to eql(20)
+    end
+
+    it "should fail if echo is enabled but not supported by server" do
+      expect do
+        with_em_timeout do
+          OldInfoServer.start {
+            NATS.connect(uri: "nats://127.0.0.1:9997", no_echo: true) do |nc|
+            end
+          }
+        end
+      end.to raise_error(NATS::ServerError)
+    end
+
+    it "should fail if echo is enabled but not supported by server protocol" do
+      expect do
+        with_em_timeout do
+          OldProtocolInfoServer.start {
+            NATS.connect(uri: "nats://127.0.0.1:9996", no_echo: true) do |nc|
+            end
+          }
+        end
+      end.to raise_error(NATS::ServerError)
+    end
+  end
+end

--- a/spec/client/client_spec.rb
+++ b/spec/client/client_spec.rb
@@ -402,14 +402,14 @@ describe 'Client - specification' do
 
   it 'should allowing setting name for the client on connect' do
     with_em_timeout do
-      connect_command = "CONNECT {\"verbose\":false,\"pedantic\":false,\"lang\":\"#{NATS::LANG}\",\"version\":\"#{NATS::VERSION}\",\"protocol\":#{NATS::PROTOCOL_VERSION},\"name\":\"hello\"}\r\n"
+      connect_command = "CONNECT {\"verbose\":false,\"pedantic\":false,\"lang\":\"#{NATS::LANG}\",\"version\":\"#{NATS::VERSION}\",\"protocol\":#{NATS::PROTOCOL_VERSION},\"echo\":true,\"name\":\"hello\"}\r\n"
       conn = NATS.connect(:name => "hello")
       expect(conn.connect_command).to eql(connect_command)
     end
   end
 
   it 'should not repeat SUB commands when connecting' do
-    pending_commands = "CONNECT {\"verbose\":false,\"pedantic\":true,\"lang\":\"#{NATS::LANG}\",\"version\":\"#{NATS::VERSION}\",\"protocol\":#{NATS::PROTOCOL_VERSION}}\r\n"
+    pending_commands = "CONNECT {\"verbose\":false,\"pedantic\":true,\"lang\":\"#{NATS::LANG}\",\"version\":\"#{NATS::VERSION}\",\"protocol\":#{NATS::PROTOCOL_VERSION},\"echo\":true}\r\n"
     pending_commands += "PING\r\n"
     pending_commands += "SUB hello  2\r\nSUB hello  3\r\nSUB hello  4\r\nSUB hello  5\r\nSUB hello  6\r\n"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -229,3 +229,57 @@ module SilentServer
     end
   end
 end
+
+module OldInfoServer
+
+  HOST = "127.0.0.1".freeze
+  PORT = "9997".freeze
+  URI  = "nats://#{HOST}:#{PORT}".freeze
+
+  def post_init
+    send_data('INFO {"server_id":"WxE17fQB24XOvaWlhECrhg","version":"1.3.0","host":"0.0.0.0","port":4222,"max_payload":1048576,"client_id":1}'+"\r\n")
+  end
+  
+  def receive_data(data)
+  end
+
+  class << self
+    def start(&blk)
+      EM.run {
+        EventMachine::start_server(HOST, PORT, self)
+        blk.call
+      }
+    end
+
+    def stop
+      EM.stop_event_loop
+    end
+  end
+end
+
+module OldProtocolInfoServer
+
+  HOST = "127.0.0.1".freeze
+  PORT = "9996".freeze
+  URI  = "nats://#{HOST}:#{PORT}".freeze
+
+  def post_init
+    send_data('INFO {"server_id":"WxE17fQB24XOvaWlhECrhg","version":"1.3.0","host":"0.0.0.0","port":4222,"max_payload":1048576,"client_id":1,"proto": 0}'+"\r\n")
+  end
+  
+  def receive_data(data)
+  end
+
+  class << self
+    def start(&blk)
+      EM.run {
+        EventMachine::start_server(HOST, PORT, self)
+        blk.call
+      }
+    end
+
+    def stop
+      EM.stop_event_loop
+    end
+  end
+end


### PR DESCRIPTION
Add support for `no_echo` option to avoid publishing to a client's own subscriptions.

```
NATS.connect(no_echo: true)
```